### PR TITLE
Update Bootstrapper.php

### DIFF
--- a/src/ChurchCRM/Bootstrapper.php
+++ b/src/ChurchCRM/Bootstrapper.php
@@ -105,7 +105,8 @@ namespace ChurchCRM
 
           $localeInfo = Bootstrapper::GetCurrentLocale();
           self::$bootStrapLogger->debug("Setting locale to: " . $localeInfo->getLocale());
-          setlocale(LC_ALL, $localeInfo->getLocale());
+          // try different possible locale names using postfix for language 
+          setlocale(LC_ALL, $localeInfo->getLocale(), $localeInfo->getLocale().'.UTF-8', $localeInfo->getLocale().'.utf8');
 
           // Get numeric and monetary locale settings.
           $aLocaleInfo = $localeInfo->getLocaleInfo();


### PR DESCRIPTION
#### What's this PR do?
fix the Locale cannot be displayed when the value of $localeInfo->getLocale() from the system Localization setting, sLanguage, does not match the installed language locale value in the server.

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #5637

#### What are the relevant tickets?
#### Any background context you want to provide?
#### Where should the reviewer start?
go to ssh and type  
locale -a
to view the available list of language. 

#### How should this be manually tested?
try the one language with postfix   UTF-8 or utf8

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ x] No
- Does the user documentation wiki need an update?
  -  [x ] No
- Does this need to add new data to the demo database
  -  [x ] No

